### PR TITLE
Use youtube-nocookie domain

### DIFF
--- a/youtubevid.js
+++ b/youtubevid.js
@@ -5,7 +5,7 @@ window.addEventListener("load", function () {
     const w = this.clientWidth;
     const h = this.clientHeight;
     this.innerHTML =
-      '<iframe src="//www.youtube.com/embed/' + id +
+      '<iframe src="//www.youtube-nocookie.com/embed/' + id +
       '?autoplay=1" frameborder="0" width="' + w + '" height="' + h + '" allowfullscreen></iframe>';
   }
   for (i = 0; i < v.length; i++) {


### PR DESCRIPTION
Switching the standard YouTube link to the "youtube-nocookie" link will assist some users by not setting a third-party cookie.

This is known as [privacy enhanced mode](https://support.google.com/youtube/answer/171780?hl=en#zippy=%2Cturn-on-privacy-enhanced-mode).